### PR TITLE
feat: add support for custom tab `label` text

### DIFF
--- a/.yarn/versions/dba3aa01.yml
+++ b/.yarn/versions/dba3aa01.yml
@@ -1,0 +1,2 @@
+releases:
+  docusaurus-remark-plugin-tab-blocks: minor

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ And you have:
 ## Install
 
 ```bash
-yarn add docusaurus-remark-plugin-tab-blocks
-# or
 npm install docusaurus-remark-plugin-tab-blocks
+# or
+yarn add docusaurus-remark-plugin-tab-blocks
 ```
 
 ## Usage
@@ -92,11 +92,25 @@ Whether tab choices should be [synced](https://docusaurus.io/docs/markdown-featu
 
 Each tab can be customized separately by assign a configuration object to the `tab` key. Keep in mind that the object must be parsable JSON.
 
+#### `label`
+
+- Type: `string`
+
+Sets custom tab label text.
+
+    ```bash tab={"label":"npm"}
+    npm install docusaurus-remark-plugin-tab-blocks
+    ```
+
+    ```bash tab={"label":"yarn"}
+    yarn add docusaurus-remark-plugin-tab-blocks
+    ```
+
 #### `span`
 
 - Type: `number`
 
-Use `span` option to make a tab span two or more code blocks.
+Makes a single tab wrap two or more code blocks.
 
     ```js tab={"span":2} title="SomeClass.js"
     module.exports = class SomeClass {
@@ -125,14 +139,6 @@ Use `span` option to make a tab span two or more code blocks.
 The example above will be rendered like this:
 
 <img src="https://github.com/mrazauskas/docusaurus-remark-plugin-tab-blocks/blob/main/.github/readme/span-example.gif" width="640" />
-
-## Planned
-
-This is a young library. More features are on the way:
-
-- [ ] custom `label` for each tab
-
-If you have an idea or see a missing feature, just open an issue or send a PR.
 
 ## License
 

--- a/src/__tests__/__fixtures__/full-example.md
+++ b/src/__tests__/__fixtures__/full-example.md
@@ -6,7 +6,7 @@ title: Configuring Jest
 The configuration file should simply export an object:
 
 ```js tab
-/** @type {import('jest').Config} */
+/** @type {import("jest").Config} */
 const config = {
   verbose: true,
 };
@@ -15,7 +15,7 @@ module.exports = config;
 ```
 
 ```ts tab
-import type {Config} from 'jest';
+import type { Config } from "jest";
 
 const config: Config = {
   verbose: true,

--- a/src/__tests__/__fixtures__/full-example.md
+++ b/src/__tests__/__fixtures__/full-example.md
@@ -1,3 +1,38 @@
+---
+id: configuration
+title: Configuring Jest
+---
+
+The configuration file should simply export an object:
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  verbose: true,
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  verbose: true,
+};
+
+export default config;
+```
+
+```json tab={"label":"JSON"}
+{
+  "name": "my-project",
+  "jest": {
+    "verbose": true
+  }
+}
+```
+
 ### `displayName` \[string, object]
 
 Default: `undefined`

--- a/src/__tests__/__fixtures__/label.md
+++ b/src/__tests__/__fixtures__/label.md
@@ -17,3 +17,11 @@ print('fallback python label');
 ```py tab
 print('custom Python label');
 ```
+
+```bash tab={"label":"macOS"}
+custom macOS label
+```
+
+```bash tab={"label":"Windows"}
+custom Windows label
+```

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -142,6 +142,58 @@ exports[`tab blocks plugin full example 1`] = `
 
 import TabItem from '@theme/TabItem';
 
+* * *
+
+id: configuration
+
+## title: Configuring Jest
+
+The configuration file should simply export an object:
+
+<Tabs groupId="code-examples">
+
+<TabItem value="js" label="JavaScript">
+
+\`\`\`js tab
+/** @type {import('jest').Config} */
+const config = {
+  verbose: true,
+};
+
+module.exports = config;
+\`\`\`
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+\`\`\`ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  verbose: true,
+};
+
+export default config;
+\`\`\`
+
+</TabItem>
+
+<TabItem value="json" label="JSON">
+
+\`\`\`json tab={"label":"JSON"}
+{
+  "name": "my-project",
+  "jest": {
+    "verbose": true
+  }
+}
+\`\`\`
+
+</TabItem>
+
+</Tabs>
+
 ### \`displayName\` \\[string, object]
 
 Default: \`undefined\`

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -155,7 +155,7 @@ The configuration file should simply export an object:
 <TabItem value="js" label="JavaScript">
 
 \`\`\`js tab
-/** @type {import('jest').Config} */
+/** @type {import("jest").Config} */
 const config = {
   verbose: true,
 };
@@ -168,7 +168,7 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 \`\`\`ts tab
-import type {Config} from 'jest';
+import type { Config } from "jest";
 
 const config: Config = {
   verbose: true,

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -428,6 +428,22 @@ print('custom Python label');
 
 </TabItem>
 
+<TabItem value="macos" label="macOS">
+
+\`\`\`bash tab={"label":"macOS"}
+custom macOS label
+\`\`\`
+
+</TabItem>
+
+<TabItem value="windows" label="Windows">
+
+\`\`\`bash tab={"label":"Windows"}
+custom Windows label
+\`\`\`
+
+</TabItem>
+
 </Tabs>
 "
 `;


### PR DESCRIPTION
Adds `label` property to `tab` options to allow custom tab label text.

Can be used for `npm` and `yarn` commands:

````
```bash tab={"label":"npm"}
npm install docusaurus-remark-plugin-tab-blocks
```

```bash tab={"label":"yarn"}
yarn add docusaurus-remark-plugin-tab-blocks
```
````

Or simply custom display:

````
```js tab
module.exports = async () => {
  return {
    verbose: true,
  };
};
```

```json tab={"label":"JSON"}
{
  "bail": 1,
  "verbose": true
}
```
````

Syntax highlighting is correct, because of `json` language tag:

<img width="756" alt="Screenshot 2023-02-25 at 15 05 59" src="https://user-images.githubusercontent.com/72159681/221358608-b291b4e6-dc07-4750-8982-19c393a4a9be.png">
