### PR TITLE
fix: handle spaces in `label` text

### DIFF
--- a/src/__tests__/__fixtures__/label.md
+++ b/src/__tests__/__fixtures__/label.md
@@ -25,3 +25,15 @@ custom macOS label
 ```bash tab={"label":"Windows"}
 custom Windows label
 ```
+
+```json title="spec/config.json" tab={"label":"Chrome headless"}
+{ "failFast": true }
+```
+
+```json title="spec/config.json" tab={"label":"Chrome non-headless"}
+{ "failFast": true }
+```
+
+```json title="spec/config.json" tab={"label":"Firefox"}
+{ "failFast": true }
+```

--- a/src/__tests__/__snapshots__/plugin.test.mjs.snap
+++ b/src/__tests__/__snapshots__/plugin.test.mjs.snap
@@ -412,6 +412,24 @@ import TabItem from '@theme/TabItem';
     custom Windows label
     \`\`\`
   </TabItem>
+
+  <TabItem value="chrome headless" label="Chrome headless">
+    \`\`\`json title="spec/config.json" tab={"label":"Chrome headless"}
+    { "failFast": true }
+    \`\`\`
+  </TabItem>
+
+  <TabItem value="chrome non-headless" label="Chrome non-headless">
+    \`\`\`json title="spec/config.json" tab={"label":"Chrome non-headless"}
+    { "failFast": true }
+    \`\`\`
+  </TabItem>
+
+  <TabItem value="firefox" label="Firefox">
+    \`\`\`json title="spec/config.json" tab={"label":"Firefox"}
+    { "failFast": true }
+    \`\`\`
+  </TabItem>
 </Tabs>
 "
 `;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -43,14 +43,20 @@ const importNodes = {
 };
 
 function parseMeta(nodeMeta) {
-  const tabTag = nodeMeta.match(/tab=?({.+})?/g);
-  if (tabTag == null || tabTag.length < 1) {
+  const parsedMeta = { span: 1 };
+  const tabTag = nodeMeta.match(/tab(={.+})?/g);
+
+  if (tabTag == null) {
     return null;
   }
 
-  const tabMeta = tabTag[0].split("=")[1] || "{}";
+  const tabMeta = tabTag[0].split("=")[1];
 
-  return { span: 1, ...JSON.parse(tabMeta) };
+  if (tabMeta == null) {
+    return parsedMeta;
+  }
+
+  return { ...parsedMeta, ...JSON.parse(tabMeta) };
 }
 
 function createTabs(tabNodes, { groupId, labels, sync }) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -43,8 +43,10 @@ const importNodes = {
 };
 
 function parseMeta(nodeMeta) {
-  const tabTag = nodeMeta.split(" ").filter((tag) => tag.startsWith("tab"));
-  if (tabTag.length < 1) return null;
+  const tabTag = nodeMeta.match(/tab=?({.+})?/g);
+  if (tabTag == null || tabTag.length < 1) {
+    return null;
+  }
 
   const tabMeta = tabTag[0].split("=")[1] || "{}";
 


### PR DESCRIPTION
Fixes #191

It must be possible to have spaces in the tab label text. The following should work:

````md
```json title="spec/config.json" tab={"label":"Chrome headless"}
{ "failFast": true }
```
````