### PR TITLE
fix: normalize text passed to the `value` property of `TabItem`

### DIFF
--- a/src/__tests__/__snapshots__/plugin.test.mjs.snap
+++ b/src/__tests__/__snapshots__/plugin.test.mjs.snap
@@ -413,13 +413,13 @@ import TabItem from '@theme/TabItem';
     \`\`\`
   </TabItem>
 
-  <TabItem value="chrome headless" label="Chrome headless">
+  <TabItem value="chrome-headless" label="Chrome headless">
     \`\`\`json title="spec/config.json" tab={"label":"Chrome headless"}
     { "failFast": true }
     \`\`\`
   </TabItem>
 
-  <TabItem value="chrome non-headless" label="Chrome non-headless">
+  <TabItem value="chrome-non-headless" label="Chrome non-headless">
     \`\`\`json title="spec/config.json" tab={"label":"Chrome non-headless"}
     { "failFast": true }
     \`\`\`

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -73,7 +73,7 @@ function createTabs(tabNodes, { groupId, labels, sync }) {
   const children = tabNodes.map(([nodes, meta]) => {
     const lang = nodes[0].lang;
     const label = meta.label ?? labels.get(lang);
-    const value = meta.label?.toLowerCase() ?? lang;
+    const value = meta.label?.toLowerCase().replace(" ", "-") ?? lang;
 
     const attributes = [{ name: "value", type: "mdxJsxAttribute", value }];
 


### PR DESCRIPTION
Sounds better to replace spaces with `-` in the text passed to the `value` property of `TabItem`.