### PR TITLE
fix(v1): handle spaces in `label` text

### DIFF
--- a/src/__tests__/__fixtures__/label.md
+++ b/src/__tests__/__fixtures__/label.md
@@ -25,3 +25,15 @@ custom macOS label
 ```bash tab={"label":"Windows"}
 custom Windows label
 ```
+
+```json title="spec/config.json" tab={"label":"Chrome headless"}
+{ "failFast": true }
+```
+
+```json title="spec/config.json" tab={"label":"Chrome non-headless"}
+{ "failFast": true }
+```
+
+```json title="spec/config.json" tab={"label":"Firefox"}
+{ "failFast": true }
+```

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -496,6 +496,30 @@ custom Windows label
 
 </TabItem>
 
+<TabItem value="chrome-headless" label="Chrome headless">
+
+\`\`\`json title="spec/config.json" tab={"label":"Chrome headless"}
+{ "failFast": true }
+\`\`\`
+
+</TabItem>
+
+<TabItem value="chrome-non-headless" label="Chrome non-headless">
+
+\`\`\`json title="spec/config.json" tab={"label":"Chrome non-headless"}
+{ "failFast": true }
+\`\`\`
+
+</TabItem>
+
+<TabItem value="firefox" label="Firefox">
+
+\`\`\`json title="spec/config.json" tab={"label":"Firefox"}
+{ "failFast": true }
+\`\`\`
+
+</TabItem>
+
 </Tabs>
 "
 `;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,19 +13,27 @@ const importNodes = [
 ];
 
 function parseMeta(nodeMeta) {
-  const tabTag = nodeMeta.split(" ").filter((tag) => tag.startsWith("tab"));
-  if (tabTag.length < 1) return null;
+  const parsedMeta = { span: 1 };
+  const tabTag = nodeMeta.match(/tab(={.+})?/g);
 
-  const tabMeta = tabTag[0].split("=")[1] || "{}";
+  if (tabTag == null) {
+    return null;
+  }
 
-  return { span: 1, ...JSON.parse(tabMeta) };
+  const tabMeta = tabTag[0].split("=")[1];
+
+  if (tabMeta == null) {
+    return parsedMeta;
+  }
+
+  return { ...parsedMeta, ...JSON.parse(tabMeta) };
 }
 
 function formatTabs(tabNodes, { groupId, labels, sync }) {
   function formatTabItem(nodes, meta) {
     const lang = nodes[0].lang;
     const label = meta.label ?? labels.get(lang);
-    const value = meta.label?.toLowerCase() ?? lang;
+    const value = meta.label?.toLowerCase().replace(" ", "-") ?? lang;
 
     return [
       {


### PR DESCRIPTION
Fixes #191

#192 and #193 backport for `v1`.