### PR TITLE
chore!: drop support for Node.js 14 and 19

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "src/index.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=16.14"
   },
   "scripts": {
     "lint": "yarn lint:eslint && yarn lint:prettier",


### PR DESCRIPTION
Dropping support for Node.js 14 and 19. These versions are EOL (reference: the [release schedule](https://github.com/nodejs/release#release-schedule)); and it seems like Docusaurus 3 does not plan to support them too.