### PR TITLE
chore!: drop support for Node.js 16

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -2,24 +2,6 @@
   "name": "docusaurus-remark-plugin-tab-blocks",
   "version": "2.0.0-beta",
   "description": "Turn Docusaurus code blocks into tab blocks",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mrazauskas/docusaurus-remark-plugin-tab-blocks.git"
-  },
-  "main": "src/index.js",
-  "engines": {
-    "node": ">=16.14"
-  },
-  "scripts": {
-    "lint": "yarn lint:eslint && yarn lint:prettier",
-    "lint:eslint": "eslint . --ext js,mjs",
-    "lint:prettier": "prettier . --no-config --write",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest"
-  },
-  "files": [
-    "src/*.js"
-  ],
   "keywords": [
     "docusaurus",
     "remark",
@@ -32,6 +14,21 @@
     "md",
     "mdx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mrazauskas/docusaurus-remark-plugin-tab-blocks.git"
+  },
+  "license": "MIT",
+  "main": "src/index.js",
+  "files": [
+    "src/*.js"
+  ],
+  "scripts": {
+    "lint": "yarn lint:eslint && yarn lint:prettier",
+    "lint:eslint": "eslint . --ext js,mjs",
+    "lint:prettier": "prettier . --no-config --write",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest"
+  },
   "dependencies": {
     "unist-util-is": "^4.0.0",
     "unist-util-visit": "^2.0.0"
@@ -45,5 +42,8 @@
     "remark": "14.0.3",
     "remark-mdx": "2.3.0"
   },
-  "packageManager": "yarn@3.6.4"
+  "packageManager": "yarn@3.6.4",
+  "engines": {
+    "node": ">=18.0"
+  }
 }


### PR DESCRIPTION
Dropping support for Node.js 16. It is EOL (reference: the [release schedule](https://github.com/nodejs/release#release-schedule)).

Docusaurus 3.0.0-rc.0 was published recently. It supports only Node.js 18.x or above.