### PR TITLE
fix!: allow tab groups with only one item

### DIFF
--- a/src/__tests__/__fixtures__/full-example.md
+++ b/src/__tests__/__fixtures__/full-example.md
@@ -144,3 +144,9 @@ some.method("a", "b");
 
 console.log("Calls to method: ", mockMethod.mock.calls);
 ```
+
+A single item tab group also works:
+
+```js tab
+console.log("Why not?");
+```

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -288,17 +288,34 @@ Instead of including \`jest.useFakeTimers()\` in each test file, you can enable 
     \`\`\`
   </TabItem>
 </Tabs>
+
+A single item tab group also works:
+
+<Tabs groupId="code-examples">
+  <TabItem value="js" label="JavaScript">
+    \`\`\`js tab
+    console.log("Why not?");
+    \`\`\`
+  </TabItem>
+</Tabs>
 "
 `;
 
 exports[`tab blocks plugin ignores incomplete spans 1`] = `
-"\`\`\`js tab={"span":2}
-console.log("this is first a codeblock");
-\`\`\`
+"import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-\`\`\`js
-console.log("this is second a codeblock");
-\`\`\`
+<Tabs groupId="code-examples">
+  <TabItem value="js" label="JavaScript">
+    \`\`\`js tab={"span":2}
+    console.log("this is first a codeblock");
+    \`\`\`
+
+    \`\`\`js
+    console.log("this is second a codeblock");
+    \`\`\`
+  </TabItem>
+</Tabs>
 
 \`\`\`js tab={"span":3}
 console.log("this is first a codeblock");

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -119,7 +119,9 @@ function collectTabNodes(parent, index) {
     }
   } while (nodeIndex <= parent.children.length);
 
-  if (tabNodes.length <= 1) return null;
+  if (tabNodes.length === 0) {
+    return null;
+  }
 
   return tabNodes;
 }
@@ -151,7 +153,9 @@ export function plugin(options = {}) {
       }
 
       const tabNodes = collectTabNodes(parent, index);
-      if (!tabNodes) return;
+      if (tabNodes == null) {
+        return;
+      }
 
       hasTabs = true;
       const tabs = createTabs(tabNodes, config);


### PR DESCRIPTION
Currently any tab groups with just one item are ignored. Docusaurus allows single item tab groups, so the plugin should allow these too.

For example, see https://github.com/futurice/jalapeno/pull/48