### PR TITLE
fix!: allow spans to have less items than  declared

### DIFF
--- a/src/__tests__/__fixtures__/span-incomplete.md
+++ b/src/__tests__/__fixtures__/span-incomplete.md
@@ -6,6 +6,10 @@ console.log("this is first a codeblock");
 console.log("this is second a codeblock");
 ```
 
+```js
+console.log("and one more codeblock");
+```
+
 ```js tab={"span":3}
 console.log("this is first a codeblock");
 ```
@@ -14,7 +18,7 @@ console.log("this is first a codeblock");
 console.log("this is second a codeblock");
 ```
 
-Third codeblock went missing.
+Third codeblock went missing. That can happen during development.
 
 ```ts tab={"span":2}
 console.log("this is a code ");

--- a/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -317,19 +317,31 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-\`\`\`js tab={"span":3}
-console.log("this is first a codeblock");
-\`\`\`
-
 \`\`\`js
-console.log("this is second a codeblock");
+console.log("and one more codeblock");
 \`\`\`
 
-Third codeblock went missing.
+<Tabs groupId="code-examples">
+  <TabItem value="js" label="JavaScript">
+    \`\`\`js tab={"span":3}
+    console.log("this is first a codeblock");
+    \`\`\`
 
-\`\`\`ts tab={"span":2}
-console.log("this is a code ");
-\`\`\`
+    \`\`\`js
+    console.log("this is second a codeblock");
+    \`\`\`
+  </TabItem>
+</Tabs>
+
+Third codeblock went missing. That can happen during development.
+
+<Tabs groupId="code-examples">
+  <TabItem value="ts" label="TypeScript">
+    \`\`\`ts tab={"span":2}
+    console.log("this is a code ");
+    \`\`\`
+  </TabItem>
+</Tabs>
 "
 `;
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,12 +93,10 @@ function createTabs(tabNodes, { groupId, labels, sync }) {
 }
 
 function collectTabNodes(parent, index) {
-  let nodeIndex = index;
+  let node = parent.children[index];
   const tabNodes = [];
 
   do {
-    const node = parent.children[nodeIndex];
-
     if (is(node, "code") && typeof node.meta === "string") {
       const meta = parseMeta(node.meta);
 
@@ -106,21 +104,20 @@ function collectTabNodes(parent, index) {
         break;
       }
 
-      const nodes = parent.children.slice(nodeIndex, nodeIndex + meta.span);
+      const spanItems = [];
 
-      if (
-        nodes.length === meta.span &&
-        nodes.every((node) => is(node, "code"))
-      ) {
-        tabNodes.push([nodes, meta]);
-        nodeIndex += meta.span;
-      } else {
-        break;
+      while (spanItems.length < meta.span && is(node, "code")) {
+        spanItems.push(node);
+
+        index++;
+        node = parent.children[index];
       }
+
+      tabNodes.push([spanItems, meta]);
     } else {
       break;
     }
-  } while (nodeIndex <= parent.children.length);
+  } while (index <= parent.children.length);
 
   if (tabNodes.length === 0) {
     return null;


### PR DESCRIPTION
Similar to #203

Currently the plugin silently ignores spans with less items than declared in the `"span"` option. That is puzzling behaviour and needless limitation. Should be fine to remove it.