### PR TITLE
chore: ship type definitions file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
   },
   "license": "MIT",
   "type": "module",
-  "exports": {
-    ".": "./index.js"
-  },
+  "exports": "./index.js",
   "files": [
+    "index.d.ts",
     "index.js"
   ],
   "scripts": {


### PR DESCRIPTION
Type definitions were added in #212, but did not ship.