### PR TITLE
feat: expose `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "funding": "https://github.com/sponsors/mrazauskas",
   "license": "MIT",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "index.d.ts",
     "index.js"


### PR DESCRIPTION
For example, it might be useful to load `package.json` to check version of the plugin.